### PR TITLE
Step1. 질문 삭제하기 기능 리팩토링

### DIFF
--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -43,6 +43,10 @@ public class Answer extends AbstractEntity {
         this.contents = contents;
     }
 
+    public Answer(User writer) {
+        this.writer = writer;
+    }
+
     public Answer setDeleted(boolean deleted) {
         this.deleted = deleted;
         return this;

--- a/src/main/java/qna/domain/Answers.java
+++ b/src/main/java/qna/domain/Answers.java
@@ -1,0 +1,27 @@
+package qna.domain;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import qna.CannotDeleteException;
+
+public class Answers {
+    private final List<Answer> answers;
+
+    public Answers(final List<Answer> answers) {
+        this.answers = answers;
+    }
+
+    public List<DeleteHistory> delete(User loginUser) throws CannotDeleteException {
+        List<DeleteHistory> deleteHistories = new ArrayList<>();
+        for (Answer answer : answers) {
+            if (!answer.isOwner(loginUser)) {
+                throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+            }
+            answer.setDeleted(true);
+            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
+        }
+        return deleteHistories;
+    }
+}

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -1,10 +1,24 @@
 package qna.domain;
 
-import org.hibernate.annotations.Where;
-
-import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.ForeignKey;
+import javax.persistence.JoinColumn;
+import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.OrderBy;
+
+import org.hibernate.annotations.Where;
+
+import com.sun.istack.NotNull;
+
+import qna.CannotDeleteException;
 
 @Entity
 public class Question extends AbstractEntity {
@@ -84,10 +98,41 @@ public class Question extends AbstractEntity {
         return deleted;
     }
 
-    public List<Answer> getAnswers() {
-        return answers;
+    public Answers getAnswers() {
+        return new Answers(answers);
     }
 
+    public List<DeleteHistory> delete(final User loginUser) throws CannotDeleteException {
+        if (!isOwner(loginUser)) {
+            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
+        }
+        deleted = true;
+        return deleteHistories(loginUser);
+    }
+
+    public Question addAnswers(@NotNull final List<Answer> answers) {
+        this.answers = answers;
+        return this;
+    }
+    
+    private List<DeleteHistory> deleteHistories(final User loginUser) throws CannotDeleteException {
+        List<DeleteHistory> deleteHistories = new ArrayList<>();
+        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, getId(), writer, LocalDateTime.now()));
+        deleteHistories.addAll(new Answers(answers).delete(loginUser));
+        return deleteHistories;
+    }
+
+    public Question clone(long id) {
+        Question question = new Question();
+        question.setId(id);
+        question.writer = writer;
+        question.title = title;
+        question.contents = contents;
+        question.answers = answers;
+        question.deleted = deleted;
+        return question;
+    }
+    
     @Override
     public String toString() {
         return "Question [id=" + getId() + ", title=" + title + ", contents=" + contents + ", writer=" + writer + "]";

--- a/src/main/java/qna/service/QnAService.java
+++ b/src/main/java/qna/service/QnAService.java
@@ -1,17 +1,18 @@
 package qna.service;
 
+import javax.annotation.Resource;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 import qna.CannotDeleteException;
 import qna.NotFoundException;
-import qna.domain.*;
-
-import javax.annotation.Resource;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
+import qna.domain.AnswerRepository;
+import qna.domain.Question;
+import qna.domain.QuestionRepository;
+import qna.domain.User;
 
 @Service("qnaService")
 public class QnAService {
@@ -34,25 +35,6 @@ public class QnAService {
 
     @Transactional
     public void deleteQuestion(User loginUser, long questionId) throws CannotDeleteException {
-        Question question = findQuestionById(questionId);
-        if (!question.isOwner(loginUser)) {
-            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
-        }
-
-        List<Answer> answers = question.getAnswers();
-        for (Answer answer : answers) {
-            if (!answer.isOwner(loginUser)) {
-                throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
-            }
-        }
-
-        List<DeleteHistory> deleteHistories = new ArrayList<>();
-        question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
-        for (Answer answer : answers) {
-            answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
-        }
-        deleteHistoryService.saveAll(deleteHistories);
+        deleteHistoryService.saveAll(findQuestionById(questionId).delete(loginUser));
     }
 }

--- a/src/test/java/qna/domain/AnswersTest.java
+++ b/src/test/java/qna/domain/AnswersTest.java
@@ -1,0 +1,49 @@
+package qna.domain;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import qna.CannotDeleteException;
+
+class AnswersTest {
+    @DisplayName("답변 소유자 외에 다른 사람이 작성한 답변이 없다면 답변 삭제상태를 true 로 바꾸고 삭제 히스토리를 리턴한다.")
+    @Test
+    void delete() throws CannotDeleteException {
+        User owner = user(123L);
+        List<Answer> answers = List.of(new Answer(owner), new Answer(owner));
+        
+        assertThat(new Answers(answers).delete(owner))
+                .containsExactlyElementsOf(List.of(
+                        new DeleteHistory(ContentType.ANSWER, answers.get(0).getId(), answers.get(0).getWriter(), LocalDateTime.now()),
+                        new DeleteHistory(ContentType.ANSWER, answers.get(1).getId(), answers.get(1).getWriter(), LocalDateTime.now())
+                ));
+        assertThat(answers).allSatisfy((Answer answer) -> answer.isDeleted());
+    }
+
+    @DisplayName("답변 소유자외에 다른 사람이 작성한 답변이 있다면 예외를 발생시킨다.")
+    @Test
+    void delete_when_invalid_owner() {
+        User owner = user(123L);
+        User other = user(321L);
+
+        assertThatThrownBy(() -> new Answers(List.of(new Answer(owner), new Answer(other))).delete(other))
+                .isInstanceOf(CannotDeleteException.class)
+                .hasMessage("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+    }
+    
+    private User user(long id) {
+        return new User(id, "userId", "password", "name", "email");
+    }
+
+    /*private void verifyDeleteHistories(Question question, Answer answer) {
+        List<DeleteHistory> deleteHistories = Arrays.asList(
+                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter(), LocalDateTime.now()),
+                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
+        verify(deleteHistoryService).saveAll(deleteHistories);
+    }*/
+}

--- a/src/test/java/qna/domain/AnswersTest.java
+++ b/src/test/java/qna/domain/AnswersTest.java
@@ -11,39 +11,25 @@ import org.junit.jupiter.api.Test;
 import qna.CannotDeleteException;
 
 class AnswersTest {
+    public static final List<Answer> SAME_OWNER = List.of(new Answer(UserTest.JAVAJIGI), new Answer(UserTest.JAVAJIGI));
+    public static final List<Answer> DIFFERENT_OWNER = List.of(new Answer(UserTest.JAVAJIGI), new Answer(UserTest.SANJIGI));
+    
     @DisplayName("답변 소유자 외에 다른 사람이 작성한 답변이 없다면 답변 삭제상태를 true 로 바꾸고 삭제 히스토리를 리턴한다.")
     @Test
     void delete() throws CannotDeleteException {
-        User owner = user(123L);
-        List<Answer> answers = List.of(new Answer(owner), new Answer(owner));
-        
-        assertThat(new Answers(answers).delete(owner))
+        assertThat(new Answers(SAME_OWNER).delete(UserTest.JAVAJIGI))
                 .containsExactlyElementsOf(List.of(
-                        new DeleteHistory(ContentType.ANSWER, answers.get(0).getId(), answers.get(0).getWriter(), LocalDateTime.now()),
-                        new DeleteHistory(ContentType.ANSWER, answers.get(1).getId(), answers.get(1).getWriter(), LocalDateTime.now())
+                        new DeleteHistory(ContentType.ANSWER, SAME_OWNER.get(0).getId(), SAME_OWNER.get(0).getWriter(), LocalDateTime.now()),
+                        new DeleteHistory(ContentType.ANSWER, SAME_OWNER.get(1).getId(), SAME_OWNER.get(1).getWriter(), LocalDateTime.now())
                 ));
-        assertThat(answers).allSatisfy((Answer answer) -> answer.isDeleted());
+        assertThat(SAME_OWNER).allSatisfy((Answer answer) -> answer.isDeleted());
     }
 
     @DisplayName("답변 소유자외에 다른 사람이 작성한 답변이 있다면 예외를 발생시킨다.")
     @Test
     void delete_when_invalid_owner() {
-        User owner = user(123L);
-        User other = user(321L);
-
-        assertThatThrownBy(() -> new Answers(List.of(new Answer(owner), new Answer(other))).delete(other))
+        assertThatThrownBy(() -> new Answers(DIFFERENT_OWNER).delete(UserTest.SANJIGI))
                 .isInstanceOf(CannotDeleteException.class)
                 .hasMessage("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
     }
-    
-    private User user(long id) {
-        return new User(id, "userId", "password", "name", "email");
-    }
-
-    /*private void verifyDeleteHistories(Question question, Answer answer) {
-        List<DeleteHistory> deleteHistories = Arrays.asList(
-                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter(), LocalDateTime.now()),
-                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
-        verify(deleteHistoryService).saveAll(deleteHistories);
-    }*/
 }

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -1,6 +1,45 @@
 package qna.domain;
 
+import static org.assertj.core.api.Assertions.*;
+import static qna.domain.AnswersTest.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import qna.CannotDeleteException;
+
 public class QuestionTest {
     public static final Question Q1 = new Question("title1", "contents1").writeBy(UserTest.JAVAJIGI);
     public static final Question Q2 = new Question("title2", "contents2").writeBy(UserTest.SANJIGI);
+
+    @DisplayName("질문 소유자와 로그인 한 사용자가 같고, 답변 소유자 외에 다른 사용자가 작성한 답변이 없다면 질문 삭제상태를 true 로 바꾸고 삭제 이력을 리턴한다.")
+    @Test
+    void delete() throws CannotDeleteException {
+        long id = 123L;
+        Question question = Q1.clone(id).addAnswers(SAME_OWNER);
+        List<DeleteHistory> histories = question.delete(UserTest.JAVAJIGI);
+        
+        assertThat(question.isDeleted()).isTrue();
+        assertThat(histories).hasSameElementsAs(List.of(
+                new DeleteHistory(ContentType.QUESTION, id, UserTest.JAVAJIGI, LocalDateTime.now()),
+                new DeleteHistory(ContentType.ANSWER, SAME_OWNER.get(0).getId(), SAME_OWNER.get(0).getWriter(), LocalDateTime.now()),
+                new DeleteHistory(ContentType.ANSWER, SAME_OWNER.get(1).getId(), SAME_OWNER.get(1).getWriter(), LocalDateTime.now())
+        ));
+    }
+
+    @DisplayName("답변 소유자 외에 다른 사용자가 작성한 답변이 있다면 CannotDeleteException 예외를 발생시킨다.")
+    @Test
+    void delete_when_invalid_answer_owner() {
+        Question question = Q1.clone(123L).addAnswers(DIFFERENT_OWNER);
+        assertThatThrownBy(() -> question.delete(UserTest.JAVAJIGI)).isInstanceOf(CannotDeleteException.class).hasMessage("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+    }
+
+    @DisplayName("질문 소유자와 로그인 한 사용자가 다르다면 CannotDeleteException 예외를 발생시킨다.")
+    @Test
+    void delete_when_invalid_question_owner() {
+        assertThatThrownBy(() -> Q1.delete(Q2.getWriter())).isInstanceOf(CannotDeleteException.class).hasMessage("질문을 삭제할 권한이 없습니다.");
+    }
 }

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -1,6 +1,7 @@
 package qna.service;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -40,8 +41,9 @@ public class QnaServiceTest {
         question.addAnswer(answer);
     }
 
+    @DisplayName("로그인 한 사용자와 질문한 사람이 같고 질문한 사람 외에 다른 사람의 답변이 없다면 질문의 삭제상태를 true 로 변경하고 삭제이력을 저장한다.")
     @Test
-    public void delete_성공() throws Exception {
+    public void deleteQuestion() throws Exception {
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
 
         assertThat(question.isDeleted()).isFalse();


### PR DESCRIPTION
* 추가
- `Answers` 클래스를 생성하여 객체에게 삭제역할과 책임을 위임

* 변경
- `Question` 객체에게 삭제 역할과 책임을 위임
- `QnaService` 객체는 삭제를 Question 에게 메시지만 날리며 위임하고, 실제 데이터 반영을 위한(DB) 비즈니스 레이어에 삭제 이력을 저장하도록 메시지를 전송

* 참고사항
- `Question` 과 `Answer` 객체가 양방향 의존성 문제가 있는데 이 부분은 다음 기회에 리팩토링 하겠습니다!